### PR TITLE
Fix deploy script filename

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   ],
   "scripts": {
     "start": "static-server . --port 9010",
-    "deploy": "deploy.bash"
+    "deploy": "./deploy.sh"
   },
   "devDependencies": {
     "static-server": "^2.2.1"


### PR DESCRIPTION
It was accidentally named with a `.bash` file extension, which is the extension I'm in the habit of using for Bash scripts. The actual script uses `.sh` for consistency with Bash scripts in the rest of MetaMask.