### PR TITLE
Fix start script

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "/dist"
   ],
   "scripts": {
-    "start": "static-server . --port 9010",
+    "start": "static-server ./dist --port 9010",
     "deploy": "./deploy.sh"
   },
   "devDependencies": {


### PR DESCRIPTION
The start script wasn't updated when the content to be served was moved to the `dist` directory.