### PR TITLE
Remove forwarder registration

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -13,41 +13,20 @@ const getParentWindow = () => {
   throw new Error('Cannot determine parent window')
 }
 
-const registerForwarder = async (parentLocation) => {
-  if (!window.ethereum._metamask.registerOnboardingForwarder) {
-    throw new Error('Onboarding not supported by current version of MetaMask')
-  }
-
-  await window.ethereum._metamask.registerOnboardingForwarder(parentLocation)
-}
-
 const receiveParentMessage = (event) => {
-  if (event.data.type === 'metamask:setParentLocation') {
-    if (event.origin !== new URL(event.data.location).origin) {
-      return console.log(`Location '${event.data.location}' doesn't match origin '${event.origin}'`)
-    }
-    console.log(`Parent location received: '${event.data.location}'`)
-    registerForwarder(event.data.location)
-    clearInterval(reloadParentInterval)
-  } else {
-    console.log(`Ignoring unrecognized message from parent`)
-  }
-}
-
-const receiveContentScriptMessage = (event) => {
-  if (event.data.type === 'metamask:onboardingcomplete') {
+  if (event.data.type === 'metamask:registrationCompleted') {
     console.log('Onboarding complete; closing window')
     window.close()
+  } else {
+    console.debug(`Ignoring unrecognized message from parent`)
   }
 }
 
 const receiveMessage = (event) => {
   if (event.source === parentWindow) {
     receiveParentMessage(event)
-  } else if (event.origin === new URL(window.location.href).origin) {
-    receiveContentScriptMessage(event)
   } else {
-    return console.log(`Ignoring cross-domain message from '${event.origin}'`)
+    return console.debug(`Ignoring cross-domain message from '${event.origin}'`)
   }
 }
 
@@ -59,7 +38,7 @@ const initialize = () => {
   parentWindow = getParentWindow()
   window.addEventListener('message', receiveMessage)
   reloadParentInterval = setInterval(() => {
-    console.log('Sending metamask:reload message')
+    console.debug('Sending metamask:reload message')
     parentWindow.postMessage({ type: 'metamask:reload' }, '*')
   }, parentMessageInterval)
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/forwarder",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Forwarding page for one-click onboarding",
   "homepage": "https://github.com/MetaMask/forwarder#readme",
   "bugs": {


### PR DESCRIPTION
*  Remove forwarder registration and update close handler

   The registration of the forwarder with MetaMask was removed from the onboarding library and from MetaMask, but the vestigial message handlers were left here in the forwarder. The forwarder wasn't listening for the `metamask:registrationComplete` message from the onboarding library either. Functionally the forwarder still worked, but it left a few pointless logs and wouldn't close properly in some cases.

   The `registrationComplete` message is now handled correctly, and the obsolete code has been removed.

* Update version to v1.1.0
